### PR TITLE
fix: fix typo in 2025-10-16-hifi-hyprland-firefox-crash

### DIFF
--- a/site/posts/2025-10-16-hifi-hyprland-firefox-crash.org
+++ b/site/posts/2025-10-16-hifi-hyprland-firefox-crash.org
@@ -127,5 +127,5 @@ After a =nixos-rebuild switch --flake .#= I now have a laptop setup where
 =Firefox= no longer crashes when I unplug USB-C cables connected to external
 displays. Great success!
 
-Once the fix to makes it into the next =NixOS= stable release I can remove the
+Once the fix makes it into the next =NixOS= stable release I can remove the
 overlay and use the stock package.


### PR DESCRIPTION
## Summary

Fixes a small typo at the end of [2025-10-16-hifi-hyprland-firefox-crash](https://myme.no/posts/2025-10-16-hifi-hyprland-firefox-crash.html).

## Additional Note

Thanks for this blog - I ran into the exact same issue on Fedora. You pointed me in the right direction, I noted that I was a few versions behind!

Please accept this small patch as a token of my appreciation :)